### PR TITLE
Fix a misbehaving input

### DIFF
--- a/xander_mod_core/lists/entities.lua
+++ b/xander_mod_core/lists/entities.lua
@@ -334,7 +334,7 @@ xm_production_entities["chemical-machine"] = {
 			{
 				production_type = "input",
 				pipe_covers = pipecoverspictures(),
-				base_level = 1,
+				base_level = -1,
 				pipe_connections = {{type = "input", position = {0, -2}}}
 			},
 			{


### PR DESCRIPTION
The base_level on one of the electrolyzer fluid inputs was set too high.

Reported here: https://mods.factorio.com/mod/xander-mod/discussion/5ef838ec4183fffaf70442e6

Note for owner: I've been meaning to get more into Lua and github and a 1 character change seemed like the best way to start.